### PR TITLE
Fix argmax bug to support batches in arn_generic.py

### DIFF
--- a/examples/arn_generic.py
+++ b/examples/arn_generic.py
@@ -169,9 +169,9 @@ def main(main_params):
 				lnsa2 = softmax(lnss2)
 				lnsgrad_s2 = (lnsa2 - lnsy) / batchsize
 				lnsgrad_a1 = lnsgrad_s2 @ xl.transpose(lnsW2[1:])
-				lnsdelta_W2 = xl.transpose(xl.hstack((lnsones, lnsa1))) * lnsgrad_s2
+				lnsdelta_W2 = xl.transpose(xl.hstack((lnsones, lnsa1))) @ lnsgrad_s2
 				lnsgrad_s1 = lnsmask * lnsgrad_a1
-				lnsdelta_W1 = xl.transpose(xl.hstack((lnsones, lnsx))) * lnsgrad_s1
+				lnsdelta_W1 = xl.transpose(xl.hstack((lnsones, lnsx))) @ lnsgrad_s1
 				lnsW2 -= (lr * (lnsdelta_W2 + (_lambda * lnsW2)))
 				lnsW1 -= (lr * (lnsdelta_W1 + (_lambda * lnsW1)))
 

--- a/src/xlns.py
+++ b/src/xlns.py
@@ -143,18 +143,18 @@ def float64(x):
   else:
    return np.float64(x)
 
-def xlnsapplynpfunc(x,xlnsnp_func,xlnsnpv_func,xlnsnpb_func,xlnsnpr_func,np_func):
+def xlnsapplynpfunc(x,xlnsnp_func,xlnsnpv_func,xlnsnpb_func,xlnsnpr_func,np_func,**kwargs):
   #print(type(x))
   if isinstance(x,xlnsnpv): 
-    return xlnsnpv_func(x)
+    return xlnsnpv_func(x, **kwargs)
   elif isinstance(x,xlnsnp): #incl xlnsnpv
-    return xlnsnp_func(x)
+    return xlnsnp_func(x, **kwargs)
   elif isinstance(x,xlnsnpb): 
-    return xlnsnpb_func(x)
+    return xlnsnpb_func(x, **kwargs)
   elif isinstance(x,xlnsnpr):
-    return xlnsnpr_func(x)
+    return xlnsnpr_func(x, **kwargs)
   else:
-    return np_func(x)
+    return np_func(x, **kwargs)
 
 
 transpose = lambda x: xlnsapplynpfunc(x,xlnsnp.transpose,xlnsnpv.transpose,xlnsnpb.transpose,xlnsnpr.transpose,np.transpose)
@@ -162,7 +162,7 @@ ravel = lambda x: xlnsapplynpfunc(x,xlnsnp.ravel,xlnsnpv.ravel,xlnsnpb.ravel,xln
 shape = lambda x: xlnsapplynpfunc(x,xlnsnp.shape,xlnsnpv.shape,xlnsnpb.shape,xlnsnpr.shape,lambda x:x.shape)
 size = lambda x: xlnsapplynpfunc(x,xlnsnp.size,xlnsnpv.size,xlnsnpb.size,xlnsnpr.size,lambda x:x.size)
 sign = lambda x: xlnsapplynpfunc(x,xlnsnp.sign,xlnsnpv.sign,xlnsnpb.sign,xlnsnpr.sign,np.sign)
-argmax = lambda x,axis=None: xlnsapplynpfunc(x,xlnsnp.argmax,xlnsnpv.argmax,xlnsnpb.argmax,xlnsnpr.argmax,np.argmax)
+argmax = lambda x,axis=None: xlnsapplynpfunc(x,xlnsnp.argmax,xlnsnpv.argmax,xlnsnpb.argmax,xlnsnpr.argmax,np.argmax,axis=axis)
 
 def xlnswhere(x,vt,vf):
   if isinstance(x,xlnsnpv): 


### PR DESCRIPTION
`xlns.argmax` doesn't pass the `axis` parameter through to `xlns.xlnsapplynpfunc` which causes it to default to axis=0. In particular, this leads to bugs with `minibatch_size` > 1 in `arn_generic.py`. This is fixed by adding the `**kwargs` parameter to `xlns.xlnsapplynpfunc` and then passing that through to the corresponding functions. 

In `arn_generic.py`, I changed standard multiplication symbols to matrix multiplication in the backpropagation as in the original code from Arnab Sanyal to allow for `minibatch_size` > 1.