### PR TITLE
Updated xlns.py file to handle edge cases of division by 0 in xlns and xlnsnp classes similar to tensorflow, and print them correctly

### DIFF
--- a/src/xlns.py
+++ b/src/xlns.py
@@ -219,7 +219,10 @@ class xlns:
   xlns1stCons = False
   if isinstance(v,int) or isinstance(v,float):
    if abs(v)!=0: #handling of infinity is needed
-    self.x = int(round(math.log(abs(v))/math.log(xlnsB)))
+    if math.isinf(abs(v)):
+      self.x=float('inf')
+    else:
+      self.x = int(round(math.log(abs(v))/math.log(xlnsB)))
    else:
     self.x = -1e1000 #-inf
    self.s = False if v>=0.0 else True 

--- a/src/xlns.py
+++ b/src/xlns.py
@@ -263,16 +263,20 @@ class xlns:
  def __int__(self):
   return int(float(self))
  def __str__(self):
+  
   if self.x == -1e1000:
-   return "0"
+   return ("-" if self.s else "")+"0" #signed zero like tensorflow
+  if math.isinf(self.x):
+    return ("-" if self.s else "")+"inf"
   log10 = self.x/(math.log(10)/math.log(xlnsB))
-  #print("log10=",log10)
-  if abs(log10)>10:
-   return ("-" if self.s else "")+str(10.0**(log10%1))+"E"+str(math.floor(log10))
+  
+  if abs(log10)>10:#use scientific notation
+   
+   return ("-" if self.s else "")+ str(10.0**(log10%1))+"E"+str(math.floor(log10))
   else: 
    return str(float(self))
  def __repr__(self):
-  return "xlns("+str(self)+")"
+  return "xlns("+str(float(self))+")" #using float gives infinity in xlnsnp objects instead of precise representation of long float strings
  def conjugate(self):  #needed for .var() and .std() in numpy
   return(self)
  def __abs__(self):

--- a/src/xlns.py
+++ b/src/xlns.py
@@ -218,7 +218,7 @@ class xlns:
   global xlns1stCons
   xlns1stCons = False
   if isinstance(v,int) or isinstance(v,float):
-   if abs(v)!=0:
+   if abs(v)!=0: #handling of infinity is needed
     self.x = int(round(math.log(abs(v))/math.log(xlnsB)))
    else:
     self.x = -1e1000 #-inf

--- a/src/xlns.py
+++ b/src/xlns.py
@@ -552,20 +552,20 @@ def xlnscopy(x,xlnstype=xlns,setFB=None):
   """deep copy of list converting to xlns (or type and precision specified by 2nd and 3rd args)"""
   r=[]
   for y in x:
-   if isinstance(y,list) or isinstance(y,np.ndarray):
+   if isinstance(y,(list,np.ndarray)):
     if setFB == None:
-      r+=[xlnscopy(y,xlnstype)]
+      r.append(xlnscopy(y,xlnstype))
     else:
       #print('recursive setFB='+str(setFB))
-      r+=[xlnscopy(y,xlnstype,setFB)]
-   elif isinstance(y,int) or isinstance(y,float) or isinstance(y,np.float64) or isinstance(y,np.float32) or isinstance(y,xlns) or isinstance(y,xlnsr) or isinstance(y,xlnsnp) or isinstance(y,xlnsnpr) or isinstance(y,xlnsnpv) or isinstance(y,xlnsv) or isinstance(y,xlnsb):
+      r.append(xlnscopy(y,xlnstype,setFB))
+   elif isinstance(y,(int,float,np.float64,np.float32,xlns,xlnsr,xlnsnp,xlnsnpr,xlnsnpv,xlnsv,xlnsb)):
     if setFB == None:
-      r+=[xlnstype(y)]
+      r.append(xlnstype(y))
     else:
       #print('setFB='+str(setFB))
-      r+=[xlnstype(y,setFB)]
+      r.append(xlnstype(y,setFB))
    else:
-    r+=[y]
+    r.append(y)
   return r
 
 #def xlnscopy(x):

--- a/src/xlns.py
+++ b/src/xlns.py
@@ -323,8 +323,12 @@ class xlns:
    return (1/v)*self
   if not isinstance(v,xlns):
    return self/xlns(v)
-  t.x = self.x - v.x
-  t.s = self.s != v.s
+  if math.isinf(v.x): #infinity handling in denominator
+    t.x=-1e1000
+    t.s=False if v.s==self.s else True # assuming signed 0 as in tensorflow
+  else:
+    t.x = self.x - v.x
+    t.s = self.s != v.s
   return t
  def __add__(self,v):
   global xlnsB


### PR DESCRIPTION
The commits update the overloaded __truediv__ of xlns and xlnsnp classes to handle division by 0. In xlns class, negative float infinity is used to store 0 while in xlnsnp, int64min is reserved for that. In xlns, division by 0 case gets handled since in subtraction this -float infinity becomes plus infinity, but for the printing, __str__ of this class was also updated to print infinity (with the sign of the division) separately. Also this function was throwing an error as floor was being used on infinity without separate handling. Furthermore, __repr__ of this class was updated to show str(float(self)) instead of str(self) as this lets xlnsnp to output inf (like tensorflow) instead a long stringified float which is out of float bounds Also the constructor of xlns was updated to accomodate positive or negative float infinity and the divisions of a number(non zero) by infinity causing positive or negative 0 (similar to tensorflow).
Additionally, the __truediv__ of xlnsnp was updated to output float infinity on division by 0. Since 0 is represented here by INT64MIN, simple subtraction makes it reach INT64MAX which when added with a number results in a very small value. So instead of generating a large number, division by 0 was giving a very small value. So, this was handled separately: the cases of division by 0, generation of positive and negative infinity, and 0/0 (nan) are implemented. 
The representation of positive and negative infinity and nan using values close to INT64MIN and their efficacy must be verified. 