### PR TITLE
Update xlns.py to handle multidimensional lists

### DIFF
--- a/src/xlns.py
+++ b/src/xlns.py
@@ -699,7 +699,7 @@ class xlnsnp:
      self.nd = xlnsnp(np.float64(v)).nd
    else:
      t=[]
-     for y in xlnscopy(v):
+     for y in np.ravel(xlnscopy(v)):
        #print(y)
        if y.x == -1e1000:
          #print("zero")


### PR DESCRIPTION
np.ravel was used on lists to make xlnsnp handle lists like np arrays without throwing errors for multidimensional lists.