### PR TITLE
Define a Constant for Frequently Used Value

### DIFF
--- a/src/xlns.py
+++ b/src/xlns.py
@@ -13,6 +13,8 @@
 import math
 import numpy as np
 
+XLNS_MIN_INT = -0x7fffffffffffffff-1
+
 def xlnssetovf(mn,mx):
   """set min and max overflow values"""
   global ovfmin,ovfmax
@@ -630,19 +632,19 @@ class xlnsnp:
   if isinstance(v,int) or isinstance(v,float):
    #print("have scalar: "+str(v))
    if v == 0:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
      self.nd = np.array([2*xlns(v).x+xlns(v).s],dtype="i8")
   elif isinstance(v,xlns):
    if v.x == -1e1000:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
      self.nd = np.array([2*v.x+v.s],dtype="i8")
   elif isinstance(v,xlnsnp):    #copy constructor
      self.nd = v.nd
   elif isinstance(v,xlnsr):
    if v.p==v.n:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    elif v.p>v.n:
      self.nd = np.array([2*(xlns(v).x)],dtype="i8")
    else:
@@ -666,7 +668,7 @@ class xlnsnp:
         #print(y)
         if y.x == -1e1000:
            #print("zero")
-           t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+           t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
         else:
            t += [2*y.x + y.s] 
      #print("t="+repr(t))
@@ -681,14 +683,14 @@ class xlnsnp:
         if isinstance(y,xlns):
            if y.x == -1e1000:
              #print("zero")
-             t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+             t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
            else:
              t += [2*y.x + y.s] 
            #print("t="+repr(t))
         else:
            if y == 0:
              #print("zero")
-             t += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+             t += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
            else:
              t += [2*xlns(y).x + xlns(y).s] 
            #print("t="+repr(t))
@@ -703,7 +705,7 @@ class xlnsnp:
        #print(y)
        if y.x == -1e1000:
          #print("zero")
-         t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+         t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
        else:
          t += [2*y.x + y.s] 
        #print("t="+repr(t))
@@ -756,7 +758,7 @@ class xlnsnp:
   if isinstance(v,xlnsnp):
     t = xlnsnp("")
     t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff)|((v.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd + v.nd - (v.nd&1)) ^ (v.nd&1) )
     return t
   else:
@@ -767,7 +769,7 @@ class xlnsnp:
   if isinstance(v,xlnsnp):
     t = xlnsnp("")
     t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd - v.nd + (v.nd&1)) ^ (v.nd&1) )
     return t
   else:
@@ -869,7 +871,7 @@ class xlnsnp:
   return t 
  def zeros(v):
   t = xlnsnp("")
-  t.nd = np.zeros(v,dtype="i8")+(-0x7fffffffffffffff-1)
+  t.nd = np.zeros(v,dtype="i8")+(XLNS_MIN_INT)
   return t
  def sum(self,axis=None):
   """divide and conquer summation that reorders operands to minimize __add__ calls"""
@@ -963,13 +965,13 @@ class xlnsnp:
   t=xlnsnp("")
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
    if v==0:
-     t.nd=np.where(self.nd&1,0,-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,0,XLNS_MIN_INT)
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,0,np.where(self.nd<2*xlns(v).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where(self.nd<2*xlns(v).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd>(2*xlns(v).x|1),0,-0x7fffffffffffffff-1),-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,np.where(self.nd>(2*xlns(v).x|1),0,XLNS_MIN_INT),XLNS_MIN_INT)
      return t
   else:
    print("nonscalar comparison")
@@ -978,13 +980,13 @@ class xlnsnp:
   t=xlnsnp("")
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
    if v==0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where((self.nd|1)!=-0x7fffffffffffffff,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where((self.nd|1)!=-0x7fffffffffffffff,0,XLNS_MIN_INT))
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where(self.nd>2*xlns(v).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where(self.nd>2*xlns(v).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd<(2*xlns(v).x|1),0,-0x7fffffffffffffff-1),0)
+     t.nd=np.where(self.nd&1,np.where(self.nd<(2*xlns(v).x|1),0,XLNS_MIN_INT),0)
      return t
   else:
    print("nonscalar comparison")
@@ -993,13 +995,13 @@ class xlnsnp:
   t=xlnsnp("")
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
    if v==0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,0)
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,0)
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where(self.nd>=2*xlns(v).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where(self.nd>=2*xlns(v).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd<=(2*xlns(v).x|1),0,-0x7fffffffffffffff-1),0)
+     t.nd=np.where(self.nd&1,np.where(self.nd<=(2*xlns(v).x|1),0,XLNS_MIN_INT),0)
      return t
   else:
    print("nonscalar comparison")
@@ -1008,13 +1010,13 @@ class xlnsnp:
   t=xlnsnp("")
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
    if v==0:
-     t.nd=np.where(self.nd&1,0,np.where((self.nd|1)!=-0x7fffffffffffffff,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where((self.nd|1)!=-0x7fffffffffffffff,0,XLNS_MIN_INT))
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,0,np.where(self.nd<=2*xlns(v).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where(self.nd<=2*xlns(v).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd>=(2*xlns(v).x|1),0,-0x7fffffffffffffff-1),-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,np.where(self.nd>=(2*xlns(v).x|1),0,XLNS_MIN_INT),XLNS_MIN_INT)
      return t
   else:
    print("nonscalar comparison")
@@ -1022,20 +1024,20 @@ class xlnsnp:
  def __eq__(self,v):
   t=xlnsnp("")
   #if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
-  # t.nd = np.where(self.nd == 2*xlns(v).x + xlns(v).s, 0, -0x7fffffffffffffff-1)
+  # t.nd = np.where(self.nd == 2*xlns(v).x + xlns(v).s, 0, XLNS_MIN_INT)
   if not isinstance(v,xlnsnp):
-   t.nd = np.where(self.nd == xlnsnp(v).nd, 0, -0x7fffffffffffffff-1)
+   t.nd = np.where(self.nd == xlnsnp(v).nd, 0, XLNS_MIN_INT)
   else:
-   t.nd = np.where(self.nd == v.nd, 0, -0x7fffffffffffffff-1)
+   t.nd = np.where(self.nd == v.nd, 0, XLNS_MIN_INT)
   return t
  def __ne__(self,v):
   t=xlnsnp("")
   #if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns):
-  # t.nd = np.where(self.nd == 2*xlns(v).x + xlns(v).s, -0x7fffffffffffffff-1, 0)
+  # t.nd = np.where(self.nd == 2*xlns(v).x + xlns(v).s, XLNS_MIN_INT, 0)
   if not isinstance(v,xlnsnp):
-   t.nd = np.where(self.nd == xlnsnp(v).nd, -0x7fffffffffffffff-1, 0)
+   t.nd = np.where(self.nd == xlnsnp(v).nd, XLNS_MIN_INT, 0)
   else:
-   t.nd = np.where(self.nd == v.nd, -0x7fffffffffffffff-1, 0)
+   t.nd = np.where(self.nd == v.nd, XLNS_MIN_INT, 0)
   return t
 
 
@@ -1230,9 +1232,9 @@ class xlnsnpr:
      self.ndn = np.array([0],dtype="i8")      
    elif v > 0:
      self.ndp = np.array([xlns(v).x],dtype="i8")
-     self.ndn = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.ndn = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
-     self.ndp = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.ndp = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
      self.ndn = np.array([xlns(v).x],dtype="i8")
   elif isinstance(v,xlns):
    if v == 0:
@@ -1240,9 +1242,9 @@ class xlnsnpr:
      self.ndn = np.array([0],dtype="i8")      
    elif v > 0:
      self.ndp = np.array([v.x],dtype="i8")
-     self.ndn = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.ndn = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
-     self.ndp = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.ndp = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
      self.ndn = np.array([v.x],dtype="i8")
   elif isinstance(v,xlnsr):
    if v.p==v.n:
@@ -1252,11 +1254,11 @@ class xlnsnpr:
      if v.p.x != -1e1000: #-inf
         self.ndp = np.array([v.p.x],dtype="i8")
      else:
-        self.ndp = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+        self.ndp = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
      if v.n.x != -1e1000: #-inf
         self.ndn = np.array([v.n.x],dtype="i8")      
      else:
-        self.ndn = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+        self.ndn = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
   elif isinstance(v,xlnsb) or isinstance(v,xlnsv):
      temp = xlnsnpr(float(v))
      self.ndp = temp.ndp
@@ -1289,9 +1291,9 @@ class xlnsnpr:
            tn += [ 0 ]
         elif y>0:
            tp += [y.x] 
-           tn += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+           tn += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
         else:
-           tp += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+           tp += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
            tn += [y.x] 
      #print("t="+repr(t))
      self.ndp = np.array(np.reshape(tp,np.shape(v)),dtype="i8")
@@ -1312,9 +1314,9 @@ class xlnsnpr:
            tn += [ 0 ] #0x000000000000000 avoiding int64 limit
         elif y>0:
            tp += [y.x] 
-           tn += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+           tn += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
         else:
-           tp += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+           tp += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
            tn += [y.x] 
      #print("t="+repr(t))
      self.ndp = np.array(np.reshape(tp,np.shape(v)),dtype="i8")
@@ -1336,9 +1338,9 @@ class xlnsnpr:
             tn += [ 0 ] #0x000000000000000 avoiding int64 limit
          elif y>0:
             tp += [y.x] 
-            tn += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+            tn += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
          else:
-            tp += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+            tp += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
             tn += [y.x] 
       #print("t="+repr(t))
       self.ndp = np.array(np.reshape(tp,np.shape(v)),dtype="i8")
@@ -1385,19 +1387,19 @@ class xlnsnpr:
               0,                                                           #any tp==tn
               np.where(v.nd&1, 
                        np.where((self.ndn|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndn + v.nd//2),
                        np.where((self.ndp|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndp + v.nd//2))) 
     t.ndn = np.where((self.ndp==self.ndn)|((v.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001
               0,                                                           #any tp==tn
               np.where(v.nd&1, 
                        np.where((self.ndp|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndp + v.nd//2),
                        np.where((self.ndn|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndn + v.nd//2))) 
     return t
   else:
@@ -1412,19 +1414,19 @@ class xlnsnpr:
     t = xlnsnpr("")
     t.ndp = np.where(v.nd&1, 
                        np.where((self.ndn|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndn - v.nd//2),
                        np.where((self.ndp|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndp - v.nd//2)) 
                   #(self.ndn - v.nd//2),
                   #(self.ndp - v.nd//2)) 
     t.ndn = np.where(v.nd&1, 
                        np.where((self.ndp|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndp - v.nd//2),
                        np.where((self.ndn|1)==-0x7fffffffffffffff,         #obscure way to say 0x8000000000000001
-                           -0x7fffffffffffffff-1,                          #0x8000000000000000 avoiding int64 limit
+                           XLNS_MIN_INT,                          #0x8000000000000000 avoiding int64 limit
                            self.ndn - v.nd//2)) 
                   #(self.ndp - v.nd//2),
                   #(self.ndn - v.nd//2)) 
@@ -1483,7 +1485,7 @@ class xlnsnpr:
   if isinstance(v,xlnsnpr):
    t = xlnsnp("")
    t.nd = np.where( v.ndp==v.ndn, 
-                    -0x7fffffffffffffff-1, #obscure way to say 0x8000000000000000 
+                    XLNS_MIN_INT, #obscure way to say 0x8000000000000000 
                     np.where( v.ndp > v.ndn, 0, 1))
    return t
   else:
@@ -2176,7 +2178,7 @@ class xlnsnpv(xlnsnp):
   return t 
  #def zeros(v):
  # t = xlnsnpv("")
- # t.nd = np.zeros(v,dtype="i8")+(-0x7fffffffffffffff-1)
+ # t.nd = np.zeros(v,dtype="i8")+(XLNS_MIN_INT)
  # return t
  def sum(self,axis=None):
   if axis == None:
@@ -2531,12 +2533,12 @@ class xlnsnpb:
   if isinstance(v,int) or isinstance(v,float):
    #print("have scalar: "+str(v))
    if v == 0:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
      self.nd = np.array([2*xlnsb(v,setB).x+xlnsb(v,setB).s],dtype="i8") 
   elif isinstance(v,xlns) or isinstance(v,xlnsv) or isinstance(v,xlnsb):
    if v.x == -1e1000:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    else:
      self.nd = np.array([2*int(cv*v.x+.5)+v.s],dtype="i8")       #convert with rounding
   elif isinstance(v,xlnsnp) or isinstance(v,xlnsnpb):            #copy constructor includes xlnsnpv
@@ -2545,7 +2547,7 @@ class xlnsnpb:
                          np.int64(cv*(v.nd//2)+.5) )*2|(v.nd&1)  # else convert w/round mag !=0 mag, save sign
   elif isinstance(v,xlnsr):
    if v.p==v.n:
-     self.nd = np.array([-0x7fffffffffffffff-1],dtype="i8")      #0x8000000000000000 avoiding int64 limit
+     self.nd = np.array([XLNS_MIN_INT],dtype="i8")      #0x8000000000000000 avoiding int64 limit
    elif v.p>v.n:
      self.nd = np.array([2*int(cv*xlns(v).x+0.5)],dtype="i8")    #convert with round
    else:
@@ -2563,7 +2565,7 @@ class xlnsnpb:
         #print(y)
         if y.x == -1e1000:
            #print("zero")
-           t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+           t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
         else:
            t += [2*int(cv*y.x+.5) + y.s] 
      #print("t="+repr(t))
@@ -2577,14 +2579,14 @@ class xlnsnpb:
         if isinstance(y,xlns) or isinstance(y,xlnsv) or isinstance(y,xlnsb):
            if y.x == -1e1000:
              #print("zero")
-             t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+             t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
            else:
              t += [2*int(cv*y.x+.5) + y.s] 
            #print("t="+repr(t))
         else:
            if y == 0:
              #print("zero")
-             t += [ -0x7fffffffffffffff-1 ] #0x8000000000000000 avoiding int64 limit
+             t += [ XLNS_MIN_INT ] #0x8000000000000000 avoiding int64 limit
            else:
              t += [2*xlnsb(y,setB).x + xlnsb(y,setB).s] 
            #print("t="+repr(t))
@@ -2595,7 +2597,7 @@ class xlnsnpb:
        #print(y)
        if y.x == -1e1000:
          #print("zero")
-         t += [ -0x7fffffffffffffff-1 + y.s] #0x8000000000000000 avoiding int64 limit
+         t += [ XLNS_MIN_INT + y.s] #0x8000000000000000 avoiding int64 limit
        else:
          t += [2*int(cv*y.x+.5) + y.s] 
        #print("t="+repr(t))
@@ -2655,12 +2657,12 @@ class xlnsnpb:
     t = xlnsnpb("",self.B)
     if v.B == self.B:
         t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff)|((v.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd + (v.nd - (v.nd&1))) ^ (v.nd&1) )
     else:
         cv = np.log(v.B)/np.log(self.B)
         t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff)|((v.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd + np.int64(cv*(v.nd//2)+.5)*2) ^ (v.nd&1) )
     return t
   else:
@@ -2672,12 +2674,12 @@ class xlnsnpb:
     t = xlnsnpb("",self.B)
     if v.B == self.B:
         t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd - v.nd + (v.nd&1)) ^ (v.nd&1) )
     else:
         cv = np.log(v.B)/np.log(self.B)
         t.nd = np.where(((self.nd|1)==-0x7fffffffffffffff)|((v.nd|1)==-0x7fffffffffffffff), #obscure way to say 0x8000000000000001 and
-                  (-0x7fffffffffffffff-1) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
+                  (XLNS_MIN_INT) |((self.nd^v.nd)&1),                        #0x8000000000000000 avoiding int64 limit
                   (self.nd - np.int64(cv*(v.nd//2)+.5)*2) ^ (v.nd&1) )
     return t
   else:
@@ -2782,7 +2784,7 @@ class xlnsnpb:
   return t 
  def zeros(v):
   t = xlnsnpb("",xlnsB)  #arbitrary choice for precision
-  t.nd = np.zeros(v,dtype="i8")+(-0x7fffffffffffffff-1)
+  t.nd = np.zeros(v,dtype="i8")+(XLNS_MIN_INT)
   return t
  def sum(self,axis=None):
   if axis == None:
@@ -2878,13 +2880,13 @@ class xlnsnpb:
   t=xlnsnpb("",self.B)
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns) or isinstance(v,xlnsr) or isinstance(v,xlnsv) or isinstance(v,xlnsb):
    if v==0:
-     t.nd=np.where(self.nd&1,0,-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,0,XLNS_MIN_INT)
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,0,np.where(self.nd<2*xlnsb(v,self.B).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where(self.nd<2*xlnsb(v,self.B).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd>(2*xlnsb(v,self.B).x|1),0,-0x7fffffffffffffff-1),-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,np.where(self.nd>(2*xlnsb(v,self.B).x|1),0,XLNS_MIN_INT),XLNS_MIN_INT)
      return t
   else:
    print("nonscalar comparison")
@@ -2893,13 +2895,13 @@ class xlnsnpb:
   t=xlnsnpb("",self.B)
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns) or isinstance(v,xlnsr) or isinstance(v,xlnsv) or isinstance(v,xlnsb):
    if v==0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where((self.nd|1)!=-0x7fffffffffffffff,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where((self.nd|1)!=-0x7fffffffffffffff,0,XLNS_MIN_INT))
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where(self.nd>2*xlnsb(v,self.B).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where(self.nd>2*xlnsb(v,self.B).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd<(2*xlnsb(v,self.B).x|1),0,-0x7fffffffffffffff-1),0)
+     t.nd=np.where(self.nd&1,np.where(self.nd<(2*xlnsb(v,self.B).x|1),0,XLNS_MIN_INT),0)
      return t
   else:
    print("nonscalar comparison")
@@ -2908,13 +2910,13 @@ class xlnsnpb:
   t=xlnsnpb("",self.B)
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns) or isinstance(v,xlnsr) or isinstance(v,xlnsv) or isinstance(v,xlnsb):
    if v==0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,0)
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,0)
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,-0x7fffffffffffffff-1,np.where(self.nd>=2*xlnsb(v,self.B).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,XLNS_MIN_INT,np.where(self.nd>=2*xlnsb(v,self.B).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd<=(2*xlnsb(v,self.B).x|1),0,-0x7fffffffffffffff-1),0)
+     t.nd=np.where(self.nd&1,np.where(self.nd<=(2*xlnsb(v,self.B).x|1),0,XLNS_MIN_INT),0)
      return t
   else:
    print("nonscalar comparison")
@@ -2923,13 +2925,13 @@ class xlnsnpb:
   t=xlnsnpb("",self.B)
   if isinstance(v,int) or isinstance(v,float) or isinstance(v,xlns) or isinstance(v,xlnsr) or isinstance(v,xlnsv) or isinstance(v,xlnsb):
    if v==0:
-     t.nd=np.where(self.nd&1,0,np.where((self.nd|1)!=-0x7fffffffffffffff,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where((self.nd|1)!=-0x7fffffffffffffff,0,XLNS_MIN_INT))
      return t
    elif v>0:
-     t.nd=np.where(self.nd&1,0,np.where(self.nd<=2*xlnsb(v,self.B).x,0,-0x7fffffffffffffff-1))
+     t.nd=np.where(self.nd&1,0,np.where(self.nd<=2*xlnsb(v,self.B).x,0,XLNS_MIN_INT))
      return t
    else:
-     t.nd=np.where(self.nd&1,np.where(self.nd>=(2*xlnsb(v,self.B).x|1),0,-0x7fffffffffffffff-1),-0x7fffffffffffffff-1)
+     t.nd=np.where(self.nd&1,np.where(self.nd>=(2*xlnsb(v,self.B).x|1),0,XLNS_MIN_INT),XLNS_MIN_INT)
      return t
   else:
    print("nonscalar comparison")
@@ -2937,20 +2939,20 @@ class xlnsnpb:
  def __eq__(self,v):
   t=xlnsnpb("",self.B)
   if not isinstance(v,xlnsnpb):
-   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, 0, -0x7fffffffffffffff-1)
+   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, 0, XLNS_MIN_INT)
   elif self.B == v.B:
-   t.nd = np.where(self.nd == v.nd, 0, -0x7fffffffffffffff-1)
+   t.nd = np.where(self.nd == v.nd, 0, XLNS_MIN_INT)
   else:
-   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, 0, -0x7fffffffffffffff-1)
+   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, 0, XLNS_MIN_INT)
   return t
  def __ne__(self,v):
   t=xlnsnpb("",self.B)
   if not isinstance(v,xlnsnpb):
-   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, -0x7fffffffffffffff-1, 0)
+   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, XLNS_MIN_INT, 0)
   elif self.B == v.B:
-   t.nd = np.where(self.nd == v.nd, -0x7fffffffffffffff-1, 0)
+   t.nd = np.where(self.nd == v.nd, XLNS_MIN_INT, 0)
   else:
-   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, -0x7fffffffffffffff-1, 0)
+   t.nd = np.where(self.nd == xlnsnpb(v,self.B).nd, XLNS_MIN_INT, 0)
   return t
 xlnsnp.sum_default = xlnsnp.sum
 xlnsnpv.sum_default = xlnsnpv.sum


### PR DESCRIPTION
**REPLACE** all occurrences of `-0x7fffffffffffffff-1` with `XLNS_MIN_INT` throughout the xlns.py

The value `-0x7fffffffffffffff-1` appears multiple times in the code. This value is used to represent the minimum integer value (effectively 0x8000000000000000 but avoiding int64 limit issues). Defining it as a constant will:

1. Make the code more readable
2. Reduce the risk of typos
3. Make it easier to change this value if needed in the future