### PR TITLE
Prepare dev for merge to main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,81 +5,78 @@ name: Python package
 
 on:
   push:
-    branches: [ "main", "dev" ]
-  pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ main, dev ]
+  pull_request: 
 
 jobs:
 
-  build:
-    if: github.ref != 'refs/heads/dev'
+  tests:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: [ "3.9", "3.10", "3.11" ]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: System packages needed by build/tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make git
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-  build-dev:
-    if: github.ref == 'refs/heads/dev'
+      - name: Install local packages
+        run: |
+          pip install -v . ./xlnstorch
+
+      - name: Lint with flake8
+        run: |
+          # Fail immediately on serious errors
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Style report (doesn't fail the build)
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Run pytest (on xlnstorch tests)
+        run: |
+          pytest test/xlnstorch
+
+  docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: tests
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        sudo apt-get update
-        sudo apt-get install -y make git
+      - name: Set up Python for docs
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Install docs requirements
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
 
-    - name: Install xlns modules
-      run: |
-        pip install -v . ./xlnstorch
+      - name: Build docs with Sphinx
+        run: |
+          make -C docs html
 
-    - name: Run pytest on xlnstorch tests
-      run: |
-        pytest test/xlnstorch
-
-    - name: Build docs with Sphinx
-      run: |
-        if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
-        make -C docs html
-
-    - name: Deploy docs to Github Pages
-      # Only deploy if this is an actual push event (not a PR)
-      if: ${{ github.event_name == 'push' }}
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        publish_branch: gh_pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+      - name: Deploy docs to Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html
+          publish_branch: gh_pages

--- a/xlnstorch/maintainer-guide.md
+++ b/xlnstorch/maintainer-guide.md
@@ -1,0 +1,25 @@
+# Packaging and uploading to PyPi
+
+More details can be found [here](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
+
+Currently, we don't use a tool like [cibuildwheel](https://github.com/pypa/cibuildwheel) to compile
+wheels for each python version and platform. This means we must upload only the source code to pypi
+and allow the user to compile the C++ extensions on their machine.
+
+## Update the version in pyproject.toml.
+
+Increment the minor or major version appropriately from the line indicated below in pyproject.toml.
+````
+version = "1.0.0"
+````
+
+## Build
+````
+python3 -m build ./xlnstorch
+````
+
+## Upload only the source code to PyPi
+
+````
+python3 -m twine upload --repository pypi xlnstorch/dist/*.tar.gz
+````


### PR DESCRIPTION
Adds a `maintainer-guide.md` file for the xlnstorch package and modifies the github workflows to only update docs on pushes to main and to run tests on python3.9-3.11 for both xlns and xlnstorch.